### PR TITLE
Add idempotency and repeatability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## Fixed
+### Added
 
-- Fix README's examples and improve the language a little bit.
+- Added tests to verify repeatability. That is, you can navigate to the end of the input, back to the beginning of the input, back to the end of the input, etc. Keep in mind, depending on the characters in the input, the chunks are only deterministic in one direction (i.e., the last chunk moving forward may not equal the first chunk moving backwards).
+
+### Changed
+
+- Updated navigation methods to be idempotent (i.e., calling `next()` at the end of the input multiple times does not change the current chunk or update the internal index).
+
+### Fixed
+
+- Fix README's examples and improved the language a little bit.
+- Fixed a bug where the chunker might return a string starting or ending with malformed byte sequences.
 
 ## [0.2.0] - 2021-10-12
 

--- a/src/Chunker.php
+++ b/src/Chunker.php
@@ -73,6 +73,10 @@ abstract class Chunker
      */
     public function getNextChunk()
     {
+        if (!$this->hasNextChunk()) {
+            return false;
+        }
+
         return $this->getChunk(++$this->index * $this->size);
     }
 
@@ -83,13 +87,11 @@ abstract class Chunker
      */
     public function getPreviousChunk()
     {
-        $offset = --$this->index * $this->size;
-
-        if ($offset < 0) {
+        if (!$this->hasPreviousChunk()) {
             return false;
         }
 
-        return $this->getChunk($offset);
+        return $this->getChunk(--$this->index * $this->size);
     }
 
     public function hasChunk(): bool

--- a/src/File.php
+++ b/src/File.php
@@ -41,7 +41,7 @@ class File extends Chunker
             return false;
         }
 
-        return $this->getMultiByteChunk($singleByteChunk);
+        return $this->getMultiByteChunk($singleByteChunk, $offset);
     }
 
     /**
@@ -104,7 +104,7 @@ class File extends Chunker
             false,
             null,
             max(0, $offset - self::MAX_SIZE_CHARACTER),
-            $this->size + self::MAX_SIZE_CHARACTER
+            $this->size + (2 * self::MAX_SIZE_CHARACTER)
         );
     }
 
@@ -125,7 +125,7 @@ class File extends Chunker
      *     output: "ABC"
      *
      * If the intended chunk ends in the middle of a multi-byte character,
-     * `mb_strcut()` will move the cut to the right to exclude the character.
+     * `mb_strcut()` will move the cut to the right to include the character.
      *
      * For example:
      *

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -26,10 +26,8 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 {
     protected const ENCODING = 'UTF-8';
 
-    // Don't include type here, or it'll throw an exception: `Error: Typed
-    // property must not be accessed before initialization`
-    protected $systemEncoding;
-
+    protected string $systemEncoding = '';
+    
 
     protected function setUp(): void
     {

--- a/tests/TextTest.php
+++ b/tests/TextTest.php
@@ -123,6 +123,34 @@ class TextTest extends TestCase
         );
     }
 
+    public function testGetNextChunkIsIdempotentWhenSingleByteString(): void
+    {
+        $chunker = $this->singleByteChunker();
+
+        $chunker->getNextChunk();
+        $chunker->getNextChunk();
+
+        $this->assertFalse($chunker->getNextChunk());
+        $this->assertFalse($chunker->getNextChunk());
+        $this->assertFalse($chunker->getNextChunk());
+
+        $this->assertEquals($this->singleByteChunk3(), $chunker->current());
+    }
+
+    public function testGetNextChunkIsIdempotentWhenMultiByteString(): void
+    {
+        $chunker = $this->multiByteChunker();
+
+        $chunker->getNextChunk();
+        $chunker->getNextChunk();
+
+        $this->assertFalse($chunker->getNextChunk());
+        $this->assertFalse($chunker->getNextChunk());
+        $this->assertFalse($chunker->getNextChunk());
+
+        $this->assertEquals($this->multiByteChunk3(), $chunker->current());
+    }
+
     public function testNextReturnsFalseWhenNextChunkDoesNotExist(): void
     {
         $this->assertFalse($this->emptyChunker()->next());
@@ -142,6 +170,34 @@ class TextTest extends TestCase
             $this->multiByteChunk2(),
             $this->multiByteChunker()->next()
         );
+    }
+
+    public function testNextIsIdempotentWhenSingleByteString(): void
+    {
+        $chunker = $this->singleByteChunker();
+
+        $chunker->next();
+        $chunker->next();
+
+        $this->assertFalse($chunker->next());
+        $this->assertFalse($chunker->next());
+        $this->assertFalse($chunker->next());
+
+        $this->assertEquals($this->singleByteChunk3(), $chunker->current());
+    }
+
+    public function testNextIsIdempotentWhenMultiByteString(): void
+    {
+        $chunker = $this->multiByteChunker();
+
+        $chunker->next();
+        $chunker->next();
+
+        $this->assertFalse($chunker->next());
+        $this->assertFalse($chunker->next());
+        $this->assertFalse($chunker->next());
+
+        $this->assertEquals($this->multiByteChunk3(), $chunker->current());
     }
 
     public function testGetPreviousChunkReturnsFalseWhenPreviousChunkDoesNotExist(): void
@@ -167,6 +223,28 @@ class TextTest extends TestCase
         $this->assertEquals($this->multiByteChunk1(), $chunker->getPreviousChunk());
     }
 
+    public function testGetPreviousChunkIsIdempotentWhenSingleByteString(): void
+    {
+        $chunker = $this->singleByteChunker();
+
+        $this->assertFalse($chunker->getPreviousChunk());
+        $this->assertFalse($chunker->getPreviousChunk());
+        $this->assertFalse($chunker->getPreviousChunk());
+
+        $this->assertEquals($this->singleByteChunk1(), $chunker->current());
+    }
+
+    public function testGetPreviousChunkIsIdempotentWhenMultiByteString(): void
+    {
+        $chunker = $this->multiByteChunker();
+
+        $this->assertFalse($chunker->getPreviousChunk());
+        $this->assertFalse($chunker->getPreviousChunk());
+        $this->assertFalse($chunker->getPreviousChunk());
+
+        $this->assertEquals($this->multiByteChunk1(), $chunker->current());
+    }
+
     public function testPreviousReturnsFalseWhenPreviousChunkDoesNotExist(): void
     {
         $this->assertFalse($this->emptyChunker()->previous());
@@ -188,6 +266,28 @@ class TextTest extends TestCase
         $chunker->next();
 
         $this->assertEquals($this->multiByteChunk1(), $chunker->previous());
+    }
+
+    public function testPreviousIsIdempotentWhenSingleByteString(): void
+    {
+        $chunker = $this->singleByteChunker();
+
+        $this->assertFalse($chunker->previous());
+        $this->assertFalse($chunker->previous());
+        $this->assertFalse($chunker->previous());
+
+        $this->assertEquals($this->singleByteChunk1(), $chunker->current());
+    }
+
+    public function testPreviousIsIdempotentWhenMultiByteString(): void
+    {
+        $chunker = $this->multiByteChunker();
+
+        $this->assertFalse($chunker->previous());
+        $this->assertFalse($chunker->previous());
+        $this->assertFalse($chunker->previous());
+
+        $this->assertEquals($this->multiByteChunk1(), $chunker->current());
     }
 
     public function testHasChunkReturnsFalseWhenTextIsEmpty(): void
@@ -255,6 +355,52 @@ class TextTest extends TestCase
         $chunker->reset();
 
         $this->assertEquals(0, $chunker->getIndex());
+    }
+
+    public function testChunkerIsRepeatableWhenSingleByteString(): void
+    {
+        $chunker = $this->singleByteChunker();
+
+        $this->assertFalse($chunker->previous());
+
+        $this->assertEquals($this->singleByteChunk1(), $chunker->current());
+
+        $this->assertEquals($this->singleByteChunk2(), $chunker->next());
+        $this->assertEquals($this->singleByteChunk3(), $chunker->next());
+
+        $this->assertFalse($chunker->next());
+
+        $this->assertEquals($this->singleByteChunk2(), $chunker->previous());
+        $this->assertEquals($this->singleByteChunk1(), $chunker->previous());
+
+        $this->assertFalse($chunker->previous());
+
+        $this->assertEquals($this->singleByteChunk1(), $chunker->current());
+
+        $this->assertEquals($this->singleByteChunk2(), $chunker->next());
+    }
+
+    public function testChunkerIsRepeatableWhenMultiByteString(): void
+    {
+        $chunker = $this->multiByteChunker();
+
+        $this->assertFalse($chunker->previous());
+
+        $this->assertEquals($this->multiByteChunk1(), $chunker->current());
+
+        $this->assertEquals($this->multiByteChunk2(), $chunker->next());
+        $this->assertEquals($this->multiByteChunk3(), $chunker->next());
+
+        $this->assertFalse($chunker->next());
+
+        $this->assertEquals($this->multiByteChunk2(), $chunker->previous());
+        $this->assertEquals($this->multiByteChunk1(), $chunker->previous());
+
+        $this->assertFalse($chunker->previous());
+
+        $this->assertEquals($this->multiByteChunk1(), $chunker->current());
+
+        $this->assertEquals($this->multiByteChunk2(), $chunker->next());
     }
 
     protected function emptyChunker(): Text


### PR DESCRIPTION
I came here to verify the library was repeatable (i.e., you can advance to the end of the input, reverse to the beginning, advance to the end again, etc) while investigating [jstewmc/stream#2](https://github.com/jstewmc/stream/issues/2).

While I was under the hood, I realized the library was not idempotent - repeated calls to the navigation methods at the beginning or end of the string would update the internal index. So, I fixed/added that.

Finally, while I was adding tests for both, I discovered a bug in the library that might have returned a chunk with a malformed byte sequence at either end, because we weren't pulling enough content from the file.

